### PR TITLE
修复浏览器打印预览重复弹出bug

### DIFF
--- a/src/hiprint/plugins/jquery.hiwprint.js
+++ b/src/hiprint/plugins/jquery.hiwprint.js
@@ -1,5 +1,6 @@
 ﻿(function ($) {
   $.fn.hiwprint = function (options) {
+    var hasLoaded = false;
     var usedFrame = document.getElementById('hiwprint_iframe');
     if (usedFrame) usedFrame.parentNode.removeChild(usedFrame);
     var opt = $.extend({}, $.fn.hiwprint.defaults, options);
@@ -23,6 +24,8 @@
     $iframe[0].srcdoc = '<!DOCTYPE html><html><head><title></title><meta charset="UTF-8">' + css + '</head><body></body></html>';
 
     $iframe[0].onload = function () {
+      if (hasLoaded) return;
+      hasLoaded = true;
       var printDocument = $iframe[0].contentWindow || $iframe[0].contentDocument;
       if (printDocument.document) printDocument = printDocument.document;
       if (!$iframe.attr('srcdoc')) {


### PR DESCRIPTION
修复某些特定情况下 onload 函数重复调用 导致重复弹出浏览器预览打印弹窗的bug,
比如
- 前端微应用环境 切换页签时会自动调出浏览器的预览
- ...